### PR TITLE
arreglar bug en lo usuarios 

### DIFF
--- a/server/documentation/usuarios.doc.js
+++ b/server/documentation/usuarios.doc.js
@@ -95,7 +95,7 @@
  * @swagger
  * /api/usuarios/{id}:
  *  put:
- *      description: Modificar un usuario por id, para poder modificar un usuario tiene que tener el rol de administrador o ser el usuario logeado para modificacar sus propios datos
+ *      description: Modificar un usuario por id, para poder modificar un usuario tiene que tener el rol de administrador o ser el usuario logeado para modificar sus propios datos
  *      tags: [Usuarios]
  *      parameters:
  *        - name: id

--- a/server/routes/usuario.router.js
+++ b/server/routes/usuario.router.js
@@ -18,6 +18,8 @@ router.post(
   usuarioController.crearUsuario
 )
 
+router.get('/perfil', auth, usuarioController.perfilUsuario)
+
 router.get('/', auth, usuarioController.buscarUsuarios)
 
 router.get('/:id', auth, usuarioController.buscarUsuario)
@@ -25,7 +27,5 @@ router.get('/:id', auth, usuarioController.buscarUsuario)
 router.put('/:id', auth, usuarioController.modificarUsuario)
 
 router.delete('/:id', auth, usuarioController.eliminarUsuario)
-
-router.get('/perfil', auth, usuarioController.perfilUsuario)
 
 module.exports = router


### PR DESCRIPTION
Al usar express router tener al principio las rutas sin parámetros y después las rutas que tiene parámetros junto a un id

router.get('/perfil', auth, usuarioController.perfilUsuario)
router.get('/:id', auth, usuarioController.buscarUsuario)

Caso contrario /perfil lo tomara como un id de la segunda ruta 